### PR TITLE
feat: add debug mode fetch handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Loki Cloudflare Tail Worker
 
-Post logs to loki from a Cloudflare [Tail Worker].
+Post logs to [loki] from a Cloudflare [Tail Worker].
 
 ![tail worker diagram](https://developers.cloudflare.com/assets/tail-workers_hu70389a70db4cc3aeffe45d478af42800_41597_1280x532_resize_q75_box_3-1cd0ba86.png)
 
@@ -19,6 +19,22 @@ Deploy this worker to your account and set the secrets using `wrangler secret pu
 - LOKI_URL - the url to post to e.g `https://eg.grafana.net/loki/api/v1/push`
 - LOKI_TOKEN - basic auth token for loki: base64 encoded `user:pass` string
 
+For local `wrangler dev` testing, copy `example.dev.vars` to `.dev.vars` and fill out the secrets there.
+
+Curl your worker to see if it is alive
+
+```sh
+❯ curl http://127.0.0.1:8787/
+⁂ loki-dev v1.0.0
+```
+
+Enable `DEBUG = 'true'` in your `wrangler.toml` to allow sending a test message to loki to check things are working. A `204 No Content` means loki is satisfied with your offering.
+
+```sh
+❯ curl http://127.0.0.1:8787/test -i
+HTTP/1.1 204 No Content
+```
+
 Configure this worker as a `tail_consumer` in any other workers whose logs you want to send to Loki.
 
 **other worker wrangler.toml**
@@ -28,4 +44,5 @@ tail_consumers = [
 ]
 ```
 
+[loki]: https://grafana.com/docs/loki/latest/api/
 [Tail Worker]: https://developers.cloudflare.com/workers/observability/tail-workers/

--- a/example.dev.vars
+++ b/example.dev.vars
@@ -1,0 +1,5 @@
+## full url of of the push enpoint on you loki instance
+LOKI_URL="https://xyz.grafana.net/loki/api/v1/push"
+
+## base64 encoded basic auth token
+LOKI_TOKEN=""

--- a/src/loki.js
+++ b/src/loki.js
@@ -1,0 +1,93 @@
+/**
+ * POST a loki formatted message to env.LOKI_URL
+ *
+ * @typedef {object} LokiBody
+ * @prop {LokiStream[]} streams
+ *
+ * @typedef {object} LokiStream
+ * @prop {Record<string, string>} stream
+ * @prop {LokiValue[]} values
+ *
+ * @typedef {[string, string]} LokiValue
+ *
+ * @param {LokiBody} lokiBody
+ * @param {import('./worker.js').Env} env
+ */
+export async function postToLoki (lokiBody, env) {
+  const res = await fetch(env.LOKI_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${env.LOKI_TOKEN}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'loki-tail-worker'
+    },
+    body: JSON.stringify(lokiBody)
+  })
+  if (!res.ok || env.DEBUG === 'true') {
+    console.log(`${res.status} ${res.statusText} ${res.url}`)
+    if (!res.ok) {
+      throw new Error(`Failed to POST to loki ${res.status} ${res.url}`)
+    }
+  }
+  return res
+}
+
+/**
+ * @param {TraceItem} tailItem
+ */
+export function toLokiStream (tailItem) {
+  const req = formatRequest(tailItem)
+  const logs = tailItem.logs.map(formatLog)
+  const errs = tailItem.exceptions.map(formatException)
+  /** @type LokiValue[] */
+  const values = [...logs, ...errs]
+  if (req !== undefined) {
+    values.unshift(req)
+  }
+  return {
+    stream: {
+      worker: tailItem.scriptName || 'unknown',
+      outcome: tailItem.outcome
+    },
+    values
+  }
+}
+
+/** @param {number} ms epoch time in milliseconds */
+export function toNano (ms) {
+  const nano = BigInt(ms) * BigInt(1_000_000)
+  return nano.toString()
+}
+
+/**
+ * @param {TraceItem} item
+ * @returns {[string, string] | undefined}
+ **/
+export function formatRequest ({ eventTimestamp, event }) {
+  // @ts-expect-error checking for request here
+  const request = event?.request
+  if (eventTimestamp && request) {
+    const { url, method, headers, cf } = request
+    return [toNano(eventTimestamp), JSON.stringify({ url, method, headers, cf, level: 'request' })]
+  }
+}
+
+/**
+ * @param {TraceLog} log
+ * @returns {[string, string]}
+ **/
+export function formatLog ({ timestamp, message, level }) {
+  const [first, ...args] = message
+  if (typeof first === 'object') {
+    return [toNano(timestamp), JSON.stringify({ ...first, args, level })]
+  }
+  return [toNano(timestamp), JSON.stringify({ msg: first, args, level })]
+}
+
+/**
+ * @param {TraceException} e
+ * @returns {[string, string]}
+ **/
+export function formatException ({ timestamp, name, message }) {
+  return [toNano(timestamp), JSON.stringify({ msg: message, name, level: 'fatal' })]
+}

--- a/test/loki.test.js
+++ b/test/loki.test.js
@@ -1,9 +1,9 @@
-import { toLoki } from '../src/worker.js'
+import { toLokiStream } from '../src/loki.js'
 import events from './fixture/events.js'
 import test from 'ava'
 
-test('toLoki', t => {
-  const actual = toLoki(events[0])
+test('toLokiStream', t => {
+  const actual = toLokiStream(events[0])
   const { stream, values } = actual
 
   t.like(stream, {


### PR DESCRIPTION
it's not currently possible to see the logs of the tail worker itself using the cloudflare dashboard or `wrangler tail`.

this PR adds a debug fetch handler so you can check that loki is satisfied with your offerings

```sh
❯ curl http://127.0.0.1:8787/
⁂ loki-dev v1.0.0

# response is forwarded from the loki api, only enabled if env.DEBUG = 'true'
❯ curl http://127.0.0.1:8787/test -i
HTTP/1.1 204 No Content
```

License: MIT